### PR TITLE
Fix npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         ],
         "dependencies": {
                 "event-stream": "~3.0.20",
-                "iced-coffee-script": "~1.7.0",
+                "iced-coffee-script": "~1.7.0-",
                 "gulp-util": "~2.2.1"
         },
         "devDependencies": {


### PR DESCRIPTION
npm is unhappy about iced-coffee-script version:

```
npm ERR! notarget No compatible version found: iced-coffee-script@'>=1.7.0 <1.8.0'
npm ERR! notarget Valid install targets:
npm ERR! notarget [..., "1.7.0-a","1.7.1-a", ...]
```

Add a `-` to fix it.
