### PR TITLE
Update to latest iced coffee script version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         ],
         "dependencies": {
                 "event-stream": "~3.0.20",
-                "iced-coffee-script": "~1.7.0-",
+                "iced-coffee-script": "~1.8.0-",
                 "gulp-util": "~2.2.1"
         },
         "devDependencies": {


### PR DESCRIPTION
This version supports newer versions of nodejs. The `gulp-iced` project currently fails to install on v0.10.x of nodejs.
